### PR TITLE
Db fixes

### DIFF
--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -12,7 +12,6 @@ CREATE TABLE if not exists true_positives (
     attack_uid VARCHAR(60),
     sentence_id VARCHAR(60),
     true_positive TEXT,
-    element_tag TEXT,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
 );

--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -69,7 +69,7 @@ CREATE TABLE if not exists report_sentences (
     report_uid VARCHAR(60),
     text TEXT,
     html TEXT,
-    found_status TEXT,
+    found_status BOOLEAN DEFAULT 0,
     FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE
 );
 
@@ -90,6 +90,6 @@ CREATE TABLE if not exists original_html (
     report_uid VARCHAR(60),
     text TEXT,
     tag TEXT,
-    found_status TEXT,
+    found_status BOOLEAN DEFAULT 0,
     FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE
 );

--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -102,7 +102,7 @@ CREATE TABLE if not exists report_sentences (
 CREATE TABLE if not exists report_sentence_hits (
     uid VARCHAR(60) PRIMARY KEY,
     -- Attack ID
-    attack_uid TEXT,
+    attack_uid VARCHAR(60),
     -- The name of the attack
     attack_technique_name TEXT,
     -- The report ID for this sentence-hit

--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -18,26 +18,29 @@ CREATE TABLE if not exists true_positives (
 );
 
 CREATE TABLE if not exists true_negatives (
-    uid VARCHAR(60),
+    uid VARCHAR(60) PRIMARY KEY,
+    attack_uid VARCHAR(60),
     sentence_id VARCHAR(60),
     sentence TEXT,
-    FOREIGN KEY(uid) REFERENCES attack_uids(uid),
+    FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
 );
 
 CREATE TABLE if not exists false_positives (
-    uid VARCHAR(60),
+    uid VARCHAR(60) PRIMARY KEY,
+    attack_uid VARCHAR(60),
     sentence_id VARCHAR(60),
     false_positive TEXT,
-    FOREIGN KEY(uid) REFERENCES attack_uids(uid),
+    FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
 );
 
 CREATE TABLE if not exists false_negatives (
-    uid VARCHAR(60),
+    uid VARCHAR(60) PRIMARY KEY,
+    attack_uid VARCHAR(60),
     sentence_id VARCHAR(60),
     false_negative TEXT,
-    FOREIGN KEY(uid) REFERENCES attack_uids(uid),
+    FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
 );
 

--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -2,15 +2,21 @@ PRAGMA foreign_keys = ON;
 
 CREATE TABLE if not exists attack_uids (
     uid VARCHAR(60) PRIMARY KEY,
+    -- Attack description
     description TEXT,
+    -- Attack ID in the form of T<Number>
     tid TEXT,
+    -- The name of the attack
     name TEXT
 );
 
 CREATE TABLE if not exists true_positives (
     uid VARCHAR(60) PRIMARY KEY,
+    -- Attack ID
     attack_uid VARCHAR(60),
+    -- Sentence ID
     sentence_id VARCHAR(60),
+    -- The sentence itself
     true_positive TEXT,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
@@ -18,8 +24,11 @@ CREATE TABLE if not exists true_positives (
 
 CREATE TABLE if not exists true_negatives (
     uid VARCHAR(60) PRIMARY KEY,
+    -- Attack ID
     attack_uid VARCHAR(60),
+    -- Sentence ID
     sentence_id VARCHAR(60),
+    -- The sentence itself
     sentence TEXT,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
@@ -27,8 +36,11 @@ CREATE TABLE if not exists true_negatives (
 
 CREATE TABLE if not exists false_positives (
     uid VARCHAR(60) PRIMARY KEY,
+    -- Attack ID
     attack_uid VARCHAR(60),
+    -- Sentence ID
     sentence_id VARCHAR(60),
+    -- The sentence itself
     false_positive TEXT,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
@@ -36,8 +48,11 @@ CREATE TABLE if not exists false_positives (
 
 CREATE TABLE if not exists false_negatives (
     uid VARCHAR(60) PRIMARY KEY,
+    -- Attack ID
     attack_uid VARCHAR(60),
+    -- Sentence ID
     sentence_id VARCHAR(60),
+    -- The sentence itself
     false_negative TEXT,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
@@ -45,43 +60,63 @@ CREATE TABLE if not exists false_negatives (
 
 CREATE TABLE if not exists regex_patterns (
     uid VARCHAR(60) PRIMARY KEY,
+    -- Attack ID
     attack_uid VARCHAR(60),
+    -- The regex pattern
     regex_pattern TEXT,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid)
 );
 
 CREATE TABLE if not exists similar_words (
     uid VARCHAR(60) PRIMARY KEY,
+    -- Attack ID
     attack_uid TEXT,
+    -- The similar word (to the attack of attack_uid)
     similar_word TEXT,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid)
 );
 
 CREATE TABLE if not exists reports (
     uid VARCHAR(60) PRIMARY KEY,
+    -- The title of the report as submitted by the user
     title TEXT,
+    -- If applicable, the URL the user submitted for this report
     url TEXT,
+    -- Its stage in the analysis process: queue, needs review, etc.
     current_status TEXT
 );
 
 CREATE TABLE if not exists report_sentences (
     uid VARCHAR(60) PRIMARY KEY,
+    -- The report which this sentence belongs to
     report_uid VARCHAR(60),
+    -- The sentence itself
     text TEXT,
+    -- Its html representation
     html TEXT,
+    -- Whether any attacks for this sentence have been found
     found_status BOOLEAN DEFAULT 0,
     FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE
 );
 
 CREATE TABLE if not exists report_sentence_hits (
     uid VARCHAR(60) PRIMARY KEY,
+    -- Attack ID
     attack_uid TEXT,
+    -- The name of the attack
     attack_technique_name TEXT,
+    -- The report ID for this sentence-hit
     report_uid VARCHAR(60),
+    -- The sentence ID of the sentence itself
     sentence_id VARCHAR(60),
+    -- The attack T-ID
     attack_tid TEXT,
+    -- Whether the tram-analysis (not user-analysis) detected this attack for this sentence
     initial_model_match BOOLEAN DEFAULT 0,
+    -- Whether an attack is currently associated with this sentence
     active_hit BOOLEAN DEFAULT 1,
+    -- Whether a user has confirmed this attack on the sentence
+    confirmed BOOLEAN DEFAULT 0,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE,
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
@@ -89,9 +124,13 @@ CREATE TABLE if not exists report_sentence_hits (
 
 CREATE TABLE if not exists original_html (
     uid VARCHAR(60) PRIMARY KEY,
+    -- The report ID for this html element
     report_uid VARCHAR(60),
+    -- The text of this element
     text TEXT,
+    -- The element's tag
     tag TEXT,
+    -- Whether the tram-analysis (not user-analysis) detected any attack for this element
     found_status BOOLEAN DEFAULT 0,
     FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE
 );

--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -10,25 +10,36 @@ CREATE TABLE if not exists attack_uids (
 CREATE TABLE if not exists true_positives (
     uid VARCHAR(60) PRIMARY KEY,
     attack_uid VARCHAR(60),
-    sentence_id integer,
+    sentence_id VARCHAR(60),
     true_positive TEXT,
     element_tag TEXT,
-    FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid)
+    FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
+    FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
+);
+
+CREATE TABLE if not exists true_negatives (
+    uid VARCHAR(60),
+    sentence_id VARCHAR(60),
+    sentence TEXT,
+    FOREIGN KEY(uid) REFERENCES attack_uids(uid),
+    FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
 );
 
 CREATE TABLE if not exists false_positives (
     uid VARCHAR(60),
-    sentence_id integer,
+    sentence_id VARCHAR(60),
     false_positive TEXT,
-    FOREIGN KEY(uid) REFERENCES attack_uids(uid)
-    );
+    FOREIGN KEY(uid) REFERENCES attack_uids(uid),
+    FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
+);
 
 CREATE TABLE if not exists false_negatives (
     uid VARCHAR(60),
-    sentence_id INTEGER,
+    sentence_id VARCHAR(60),
     false_negative TEXT,
-    FOREIGN KEY(uid) REFERENCES attack_uids(uid)
-    );
+    FOREIGN KEY(uid) REFERENCES attack_uids(uid),
+    FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
+);
 
 CREATE TABLE if not exists regex_patterns (
     uid integer PRIMARY KEY AUTOINCREMENT,
@@ -53,7 +64,7 @@ CREATE TABLE if not exists reports (
 );
 
 CREATE TABLE if not exists report_sentences (
-    uid integer PRIMARY KEY AUTOINCREMENT,
+    uid VARCHAR(60) PRIMARY KEY,
     report_uid VARCHAR(60),
     text TEXT,
     html TEXT,
@@ -62,19 +73,16 @@ CREATE TABLE if not exists report_sentences (
 );
 
 CREATE TABLE if not exists report_sentence_hits (
-    uid INTEGER,
+    uid VARCHAR(60) PRIMARY KEY,
     attack_uid TEXT,
     attack_technique_name TEXT,
     report_uid VARCHAR(60),
+    sentence_id VARCHAR(60),
     attack_tid TEXT,
-    FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE
+    FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
+    FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE,
+    FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE
 );
-
-CREATE TABLE if not exists true_negatives (
-    uid VARCHAR(60),
-    sentence TEXT,
-    FOREIGN KEY(uid) REFERENCES attack_uids(uid)
-    );
 
 CREATE TABLE if not exists original_html (
     uid INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -80,6 +80,8 @@ CREATE TABLE if not exists report_sentence_hits (
     report_uid VARCHAR(60),
     sentence_id VARCHAR(60),
     attack_tid TEXT,
+    initial_model_match BOOLEAN DEFAULT 0,
+    active_hit BOOLEAN DEFAULT 1,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid),
     FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE,
     FOREIGN KEY(sentence_id) REFERENCES report_sentences(uid) ON DELETE CASCADE

--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -42,24 +42,23 @@ CREATE TABLE if not exists false_negatives (
 );
 
 CREATE TABLE if not exists regex_patterns (
-    uid integer PRIMARY KEY AUTOINCREMENT,
+    uid VARCHAR(60) PRIMARY KEY,
     attack_uid VARCHAR(60),
     regex_pattern TEXT,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid)
-    );
+);
 
 CREATE TABLE if not exists similar_words (
-    uid VARCHAR(60),
+    uid VARCHAR(60) PRIMARY KEY,
     attack_uid TEXT,
     similar_word TEXT,
     FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid)
-    );
+);
 
 CREATE TABLE if not exists reports (
     uid VARCHAR(60) PRIMARY KEY,
     title TEXT,
     url TEXT,
-    attack_key TEXT,
     current_status TEXT
 );
 
@@ -85,7 +84,7 @@ CREATE TABLE if not exists report_sentence_hits (
 );
 
 CREATE TABLE if not exists original_html (
-    uid INTEGER PRIMARY KEY AUTOINCREMENT,
+    uid VARCHAR(60) PRIMARY KEY,
     report_uid VARCHAR(60),
     text TEXT,
     tag TEXT,

--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -5,15 +5,16 @@ CREATE TABLE if not exists attack_uids (
     description TEXT,
     tid TEXT,
     name TEXT
-    );
+);
 
 CREATE TABLE if not exists true_positives (
-    uid VARCHAR(60),
+    uid VARCHAR(60) PRIMARY KEY,
+    attack_uid VARCHAR(60),
     sentence_id integer,
     true_positive TEXT,
     element_tag TEXT,
-    FOREIGN KEY(uid) REFERENCES attack_uids(uid)
-    );
+    FOREIGN KEY(attack_uid) REFERENCES attack_uids(uid)
+);
 
 CREATE TABLE if not exists false_positives (
     uid VARCHAR(60),
@@ -80,5 +81,3 @@ CREATE TABLE if not exists original_html (
     tag TEXT,
     found_status TEXT
     );
-
---INSERT INTO regex_patterns (attack_uid, regex_pattern) values ("attack-pattern--01df3350-ce05-4bdf-bdf8-0a919a66d4a8", "sometext.*moretext")

--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -45,28 +45,30 @@ CREATE TABLE if not exists similar_words (
     );
 
 CREATE TABLE if not exists reports (
-    uid integer PRIMARY KEY AUTOINCREMENT,
+    uid VARCHAR(60) PRIMARY KEY,
     title TEXT,
     url TEXT,
     attack_key TEXT,
     current_status TEXT
-    );
+);
 
 CREATE TABLE if not exists report_sentences (
     uid integer PRIMARY KEY AUTOINCREMENT,
-    report_uid INTEGER,
+    report_uid VARCHAR(60),
     text TEXT,
     html TEXT,
-    found_status TEXT
-    );
+    found_status TEXT,
+    FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE
+);
 
 CREATE TABLE if not exists report_sentence_hits (
     uid INTEGER,
     attack_uid TEXT,
     attack_technique_name TEXT,
-    report_uid INTEGER,
-    attack_tid TEXT
-    );
+    report_uid VARCHAR(60),
+    attack_tid TEXT,
+    FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE
+);
 
 CREATE TABLE if not exists true_negatives (
     uid VARCHAR(60),
@@ -76,8 +78,9 @@ CREATE TABLE if not exists true_negatives (
 
 CREATE TABLE if not exists original_html (
     uid INTEGER PRIMARY KEY AUTOINCREMENT,
-    report_uid INTEGER,
+    report_uid VARCHAR(60),
     text TEXT,
     tag TEXT,
-    found_status TEXT
-    );
+    found_status TEXT,
+    FOREIGN KEY(report_uid) REFERENCES reports(uid) ON DELETE CASCADE
+);

--- a/database/dao.py
+++ b/database/dao.py
@@ -11,23 +11,26 @@ class Dao:
     async def build(self, schema):
         await self.db.build(schema)
 
-    async def get(self, table, criteria=None):
-        return await self.db.get(table, criteria)
+    async def get(self, table, equal=None, not_equal=None):
+        return await self.db.get(table, equal=equal, not_equal=not_equal)
 
-    async def update(self, table, where={}, data={}):
-        await self.db.update(table, where=where, data=data)
+    async def update(self, table, where={}, data={}, return_sql=False):
+        await self.db.update(table, where=where, data=data, return_sql=return_sql)
 
-    async def insert(self, table, data):
-        return await self.db.insert(table, data)
+    async def insert(self, table, data, return_sql=False):
+        return await self.db.insert(table, data, return_sql=return_sql)
 
-    async def insert_generate_uid(self, table, data, id_field='uid'):
-        return await self.db.insert_generate_uid(table, data, id_field)
+    async def insert_generate_uid(self, table, data, id_field='uid', return_sql=False):
+        return await self.db.insert_generate_uid(table, data, id_field, return_sql=return_sql)
 
-    async def delete(self, table, data):
-        await self.db.delete(table, data)
+    async def delete(self, table, data, return_sql=False):
+        await self.db.delete(table, data, return_sql=return_sql)
 
     async def raw_query(self, query, one=False):
         return await self.db.raw_query(query, one)
         
     async def raw_select(self, query, parameters=None):
         return await self.db.raw_select(query, parameters=parameters)
+
+    async def run_sql_list(self, sql_list=None):
+        return await self.db.run_sql_list(sql_list=sql_list)

--- a/database/dao.py
+++ b/database/dao.py
@@ -20,6 +20,9 @@ class Dao:
     async def insert(self, table, data):
         return await self.db.insert(table, data)
 
+    async def insert_generate_uid(self, table, data, id_field='uid'):
+        return await self.db.insert_generate_uid(table, data, id_field)
+
     async def delete(self, table, data):
         await self.db.delete(table, data)
 

--- a/database/dao.py
+++ b/database/dao.py
@@ -14,8 +14,8 @@ class Dao:
     async def get(self, table, criteria=None):
         return await self.db.get(table, criteria)
 
-    async def update(self, table, key, value, data):
-        await self.db.update(table, key, value, data)
+    async def update(self, table, where={}, data={}):
+        await self.db.update(table, where=where, data=data)
 
     async def insert(self, table, data):
         return await self.db.insert(table, data)

--- a/database/dao.py
+++ b/database/dao.py
@@ -15,7 +15,7 @@ class Dao:
         return await self.db.get(table, equal=equal, not_equal=not_equal)
 
     async def update(self, table, where={}, data={}, return_sql=False):
-        await self.db.update(table, where=where, data=data, return_sql=return_sql)
+        return await self.db.update(table, where=where, data=data, return_sql=return_sql)
 
     async def insert(self, table, data, return_sql=False):
         return await self.db.insert(table, data, return_sql=return_sql)
@@ -24,7 +24,7 @@ class Dao:
         return await self.db.insert_generate_uid(table, data, id_field, return_sql=return_sql)
 
     async def delete(self, table, data, return_sql=False):
-        await self.db.delete(table, data, return_sql=return_sql)
+        return await self.db.delete(table, data, return_sql=return_sql)
 
     async def raw_query(self, query, one=False):
         return await self.db.raw_query(query, one)

--- a/database/tram_relation.py
+++ b/database/tram_relation.py
@@ -1,6 +1,8 @@
 import sqlite3
 import uuid
 
+ENABLE_FOREIGN_KEYS = 'PRAGMA foreign_keys = ON'
+
 
 class Attack:
 
@@ -40,7 +42,7 @@ class Attack:
                     sql += (' AND %s %s= ?' % (k, '!' if eq == 'not_equal' else ''))
                     qparams.append(v)
         with sqlite3.connect(self.database) as conn:
-            conn.execute('PRAGMA foreign_keys = ON')
+            conn.execute(ENABLE_FOREIGN_KEYS)
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
             cursor.execute(sql, tuple(qparams))
@@ -55,7 +57,7 @@ class Attack:
         if return_sql:
             return tuple([sql, tuple(data.values())])
         with sqlite3.connect(self.database) as conn:
-            conn.execute('PRAGMA foreign_keys = ON')
+            conn.execute(ENABLE_FOREIGN_KEYS)
             cursor = conn.cursor()
             cursor.execute(sql, tuple(data.values()))
             saved_id = cursor.lastrowid
@@ -111,7 +113,7 @@ class Attack:
             return tuple([sql, tuple(qparams)])
         # Run the statement by passing qparams as parameters
         with sqlite3.connect(self.database) as conn:
-            conn.execute('PRAGMA foreign_keys = ON')
+            conn.execute(ENABLE_FOREIGN_KEYS)
             cursor = conn.cursor()
             cursor.execute(sql, tuple(qparams))
             conn.commit()
@@ -129,14 +131,14 @@ class Attack:
         if return_sql:
             return tuple([sql, tuple(qparams)])
         with sqlite3.connect(self.database) as conn:
-            conn.execute('PRAGMA foreign_keys = ON')
+            conn.execute(ENABLE_FOREIGN_KEYS)
             cursor = conn.cursor()
             cursor.execute(sql, tuple(qparams))
             conn.commit()
 
     async def raw_query(self, query, one=False):
         with sqlite3.connect(self.database) as conn:
-            conn.execute('PRAGMA foreign_keys = ON')
+            conn.execute(ENABLE_FOREIGN_KEYS)
             cursor = conn.cursor()
             cursor.execute(query)
             rv = cursor.fetchall()
@@ -145,7 +147,7 @@ class Attack:
 
     async def raw_select(self, sql, parameters=None):
         with sqlite3.connect(self.database) as conn:
-            conn.execute('PRAGMA foreign_keys = ON')
+            conn.execute(ENABLE_FOREIGN_KEYS)
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
             if parameters is None:
@@ -157,7 +159,7 @@ class Attack:
 
     async def raw_update(self, sql):
         with sqlite3.connect(self.database) as conn:
-            conn.execute('PRAGMA foreign_keys = ON')
+            conn.execute(ENABLE_FOREIGN_KEYS)
             cursor = conn.cursor()
             cursor.execute(sql)
             conn.commit()
@@ -167,7 +169,7 @@ class Attack:
         if not sql_list:
             return
         with sqlite3.connect(self.database) as conn:
-            conn.execute('PRAGMA foreign_keys = ON')
+            conn.execute(ENABLE_FOREIGN_KEYS)
             cursor = conn.cursor()
             # Else, execute each item in the list where the first part must be an SQL statement
             # followed by optional parameters

--- a/database/tram_relation.py
+++ b/database/tram_relation.py
@@ -19,17 +19,25 @@ class Attack:
         except Exception as exc:
             print('! error building db : {}'.format(exc))
 
-    async def get(self, table, criteria=None):
+    async def get(self, table, equal=None, not_equal=None):
         sql = 'SELECT * FROM %s' % table
-        qparams = []
-        if criteria:
+        # Define all_params dictionary (for equal and not_equal to be None-checked and combined) and qparams list
+        all_params, qparams = dict(), []
+        # Append to all_params equal and not_equal if not None
+        all_params.update(dict(equal=equal) if equal else {})
+        all_params.update(dict(not_equal=not_equal) if not_equal else {})
+        # For each of the equal and not_equal parameters, build SQL query
+        for eq, criteria in all_params.items():
             where = next(iter(criteria))
             value = criteria.pop(where)
             if value:
-                sql += ' WHERE %s = ?' % where
+                # If this is our first criteria we are adding, we need the WHERE keyword, else adding AND
+                sql += ' AND' if len(qparams) > 0 else ' WHERE'
+                # Add the ! for != if this is a not-equals check
+                sql += (' %s %s= ?' % (where, '!' if eq == 'not_equal' else ''))
                 qparams.append(value)
                 for k, v in criteria.items():
-                    sql += ' AND %s = ?' % k
+                    sql += (' AND %s %s= ?' % (k, '!' if eq == 'not_equal' else ''))
                     qparams.append(v)
         with sqlite3.connect(self.database) as conn:
             conn.row_factory = sqlite3.Row
@@ -38,35 +46,37 @@ class Attack:
             rows = cursor.fetchall()
             return [dict(ix) for ix in rows]
 
-    async def insert(self, table, data):
+    async def insert(self, table, data, return_sql=False):
+        columns = ', '.join(data.keys())
+        temp = ['?' for i in range(len(data.values()))]
+        placeholders = ', '.join(temp)
+        sql = 'INSERT INTO {} ({}) VALUES ({})'.format(table, columns, placeholders)
+        if return_sql:
+            return tuple([sql, tuple(data.values())])
         with sqlite3.connect(self.database) as conn:
             cursor = conn.cursor()
-            columns = ', '.join(data.keys())
-            temp = ['?' for i in range(len(data.values()))]
-            placeholders = ', '.join(temp)
-            sql = 'INSERT INTO {} ({}) VALUES ({})'.format(table, columns, placeholders)
             cursor.execute(sql, tuple(data.values()))
-            id = cursor.lastrowid
+            saved_id = cursor.lastrowid
             conn.commit()
-            return id
+            return saved_id
 
-    async def insert_generate_uid(self, table, data, id_field='uid'):
+    async def insert_generate_uid(self, table, data, id_field='uid', return_sql=False):
         """Method to generate an ID value whilst inserting into db."""
         data[id_field] = str(uuid.uuid4())
         try:
             # Attempt this insertion with the ID field generated
-            await self.insert(table, data)
+            result = await self.insert(table, data, return_sql=return_sql)
         except sqlite3.IntegrityError as e:
             # If it failed because the ID was not unique, attempt once more
             if 'UNIQUE' in str(e) and table + '.' + 'uid' in str(e):
                 data[id_field] = str(uuid.uuid4())
-                await self.insert(table, data)
+                result = await self.insert(table, data, return_sql=return_sql)
             else:
                 raise e
         # Finally, return the ID value used for insertion
-        return data[id_field]
+        return result if return_sql else data[id_field]
 
-    async def update(self, table, where={}, data={}):
+    async def update(self, table, where={}, data={}, return_sql=False):
         # The list of query parameters
         qparams = []
         # Our SQL statement and optional WHERE clause
@@ -95,13 +105,15 @@ class Attack:
         where_suffix = '' if '' else ' WHERE' + where_suffix
         # Add the WHERE clause to the SQL statement
         sql += where_suffix
+        if return_sql:
+            return tuple([sql, tuple(qparams)])
         # Run the statement by passing qparams as parameters
         with sqlite3.connect(self.database) as conn:
             cursor = conn.cursor()
             cursor.execute(sql, tuple(qparams))
             conn.commit()
 
-    async def delete(self, table, data):
+    async def delete(self, table, data, return_sql=False):
         sql = 'DELETE FROM %s' % table
         qparams = []
         where = next(iter(data))
@@ -111,6 +123,8 @@ class Attack:
         for k, v in data.items():
             sql += ' AND %s = ?' % k
             qparams.append(v)
+        if return_sql:
+            return tuple([sql, tuple(qparams)])
         with sqlite3.connect(self.database) as conn:
             cursor = conn.cursor()
             cursor.execute(sql, tuple(qparams))
@@ -139,4 +153,22 @@ class Attack:
         with sqlite3.connect(self.database) as conn:
             cursor = conn.cursor()
             cursor.execute(sql)
+            conn.commit()
+
+    async def run_sql_list(self, sql_list=None):
+        # Don't do anything if we don't have a list
+        if not sql_list:
+            return
+        with sqlite3.connect(self.database) as conn:
+            cursor = conn.cursor()
+            # Else, execute each item in the list where the first part must be an SQL statement
+            # followed by optional parameters
+            for item in sql_list:
+                if len(item) == 1:
+                    cursor.execute(item[0])
+                elif len(item) == 2:
+                    # execute() takes parameters as a tuple, ensure that is the case
+                    parameters = item[1] if type(item[1]) == tuple else tuple(item[1])
+                    cursor.execute(item[0], parameters)
+            # Finish by committing the changes from the list
             conn.commit()

--- a/database/tram_relation.py
+++ b/database/tram_relation.py
@@ -40,6 +40,7 @@ class Attack:
                     sql += (' AND %s %s= ?' % (k, '!' if eq == 'not_equal' else ''))
                     qparams.append(v)
         with sqlite3.connect(self.database) as conn:
+            conn.execute('PRAGMA foreign_keys = ON')
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
             cursor.execute(sql, tuple(qparams))
@@ -54,6 +55,7 @@ class Attack:
         if return_sql:
             return tuple([sql, tuple(data.values())])
         with sqlite3.connect(self.database) as conn:
+            conn.execute('PRAGMA foreign_keys = ON')
             cursor = conn.cursor()
             cursor.execute(sql, tuple(data.values()))
             saved_id = cursor.lastrowid
@@ -109,6 +111,7 @@ class Attack:
             return tuple([sql, tuple(qparams)])
         # Run the statement by passing qparams as parameters
         with sqlite3.connect(self.database) as conn:
+            conn.execute('PRAGMA foreign_keys = ON')
             cursor = conn.cursor()
             cursor.execute(sql, tuple(qparams))
             conn.commit()
@@ -126,12 +129,14 @@ class Attack:
         if return_sql:
             return tuple([sql, tuple(qparams)])
         with sqlite3.connect(self.database) as conn:
+            conn.execute('PRAGMA foreign_keys = ON')
             cursor = conn.cursor()
             cursor.execute(sql, tuple(qparams))
             conn.commit()
 
     async def raw_query(self, query, one=False):
         with sqlite3.connect(self.database) as conn:
+            conn.execute('PRAGMA foreign_keys = ON')
             cursor = conn.cursor()
             cursor.execute(query)
             rv = cursor.fetchall()
@@ -140,6 +145,7 @@ class Attack:
 
     async def raw_select(self, sql, parameters=None):
         with sqlite3.connect(self.database) as conn:
+            conn.execute('PRAGMA foreign_keys = ON')
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
             if parameters is None:
@@ -151,6 +157,7 @@ class Attack:
 
     async def raw_update(self, sql):
         with sqlite3.connect(self.database) as conn:
+            conn.execute('PRAGMA foreign_keys = ON')
             cursor = conn.cursor()
             cursor.execute(sql)
             conn.commit()
@@ -160,6 +167,7 @@ class Attack:
         if not sql_list:
             return
         with sqlite3.connect(self.database) as conn:
+            conn.execute('PRAGMA foreign_keys = ON')
             cursor = conn.cursor()
             # Else, execute each item in the list where the first part must be an SQL statement
             # followed by optional parameters

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -100,7 +100,7 @@ class WebAPI:
         }]
 
         # Get confirmed techniques for the report from the database
-        techniques = await self.data_svc.get_confirmed_techniques(report[0]['uid'])
+        techniques = await self.data_svc.get_confirmed_techniques_for_report(report[0]['uid'])
 
         # Append techniques to enterprise layer
         for technique in techniques:

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -171,8 +171,8 @@ class WebAPI:
                 for t in true_pos:
                     tp.append(t['true_positive'])
                 # query for false negatives and false positives
-                false_neg = await self.dao.get('false_negatives', dict(uid=row['uid']))
-                false_positives = await self.dao.get('false_positives', dict(uid=row['uid']))
+                false_neg = await self.dao.get('false_negatives', dict(attack_uid=row['uid']))
+                false_positives = await self.dao.get('false_positives', dict(attack_uid=row['uid']))
                 for f in false_neg:
                     tp.append(f['false_negative'])
                 fp = []

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -61,7 +61,9 @@ class WebAPI:
         attack_uids = await self.dao.get('attack_uids')
         original_html = await self.dao.get('original_html', dict(report_uid=report[0]['uid']))
         final_html = await self.web_svc.build_final_html(original_html, sentences)
-        return dict(file=request.match_info.get('file'), title=report[0]['title'], sentences=sentences, attack_uids=attack_uids, original_html=original_html, final_html=final_html)
+        return dict(file=request.match_info.get('file'), title=report[0]['title'], sentences=sentences,
+                    attack_uids=attack_uids, original_html=original_html, final_html=final_html,
+                    report_id=report[0]['uid'], completed=int(report[0]['current_status'] == 'completed'))
 
     async def nav_export(self, request):
         """

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -36,17 +36,15 @@ class WebAPI:
         index = data.pop('index')
         options = dict(
             POST=dict(
-                false_positive=lambda d: self.rest_svc.false_positive(criteria=d),
-                true_positive=lambda d: self.rest_svc.true_positive(criteria=d),
-                false_negative=lambda d: self.rest_svc.false_negative(criteria=d),
+                add_attack=lambda d: self.rest_svc.add_attack(criteria=d),
+                reject_attack=lambda d: self.rest_svc.reject_attack(criteria=d),
                 set_status=lambda d: self.rest_svc.set_status(criteria=d),
                 insert_report=lambda d: self.rest_svc.insert_report(criteria=d),
                 insert_csv=lambda d: self.rest_svc.insert_csv(criteria=d),
                 remove_sentences=lambda d: self.rest_svc.remove_sentences(criteria=d),
                 delete_report=lambda d: self.rest_svc.delete_report(criteria=d),
                 sentence_context=lambda d: self.rest_svc.sentence_context(criteria=d),
-                confirmed_sentences=lambda d: self.rest_svc.confirmed_sentences(criteria=d),
-                missing_technique=lambda d: self.rest_svc.missing_technique(criteria=d)
+                confirmed_sentences=lambda d: self.rest_svc.confirmed_sentences(criteria=d)
             ))
         output = await options[request.method][index](data)
         return web.json_response(output)
@@ -79,7 +77,7 @@ class WebAPI:
         layer_name = f"{report_title}"
         enterprise_layer_description = f"Enterprise techniques used by {report_title}, ATT&CK"
         version = '1.0'
-        if (version): # add version number if it exists
+        if (version):  # add version number if it exists
             enterprise_layer_description += f" v{version}"
 
         # Enterprise navigator layer
@@ -89,11 +87,8 @@ class WebAPI:
         enterprise_layer['domain'] = "mitre-enterprise"
         enterprise_layer['version'] = "2.2"
         enterprise_layer['techniques'] = []
-        enterprise_layer["gradient"] = { # white for nonused, blue for used
-		    "colors": ["#ffffff", "#66b1ff"],
-		    "minValue": 0,
-    		"maxValue": 1
-	    }
+        # white for non-used, blue for used
+        enterprise_layer["gradient"] = {"colors": ["#ffffff", "#66b1ff"], "minValue": 0, "maxValue": 1}
         enterprise_layer['legendItems'] = [{
             'label': f'used by {report_title}',
             'color': "#66b1ff"

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -41,7 +41,7 @@ class WebAPI:
                 set_status=lambda d: self.rest_svc.set_status(criteria=d),
                 insert_report=lambda d: self.rest_svc.insert_report(criteria=d),
                 insert_csv=lambda d: self.rest_svc.insert_csv(criteria=d),
-                remove_sentences=lambda d: self.rest_svc.remove_sentences(criteria=d),
+                remove_sentence=lambda d: self.rest_svc.remove_sentence(criteria=d),
                 delete_report=lambda d: self.rest_svc.delete_report(criteria=d),
                 sentence_context=lambda d: self.rest_svc.sentence_context(criteria=d),
                 confirmed_attacks=lambda d: self.rest_svc.confirmed_attacks(criteria=d)

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -44,7 +44,7 @@ class WebAPI:
                 remove_sentences=lambda d: self.rest_svc.remove_sentences(criteria=d),
                 delete_report=lambda d: self.rest_svc.delete_report(criteria=d),
                 sentence_context=lambda d: self.rest_svc.sentence_context(criteria=d),
-                confirmed_sentences=lambda d: self.rest_svc.confirmed_sentences(criteria=d)
+                confirmed_attacks=lambda d: self.rest_svc.confirmed_attacks(criteria=d)
             ))
         output = await options[request.method][index](data)
         return web.json_response(output)

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -166,7 +166,7 @@ class WebAPI:
                 continue
             else:
                 # query for true positives
-                true_pos = await self.dao.get('true_positives', dict(uid=row['uid']))
+                true_pos = await self.dao.get('true_positives', dict(attack_uid=row['uid']))
                 tp = []
                 for t in true_pos:
                     tp.append(t['true_positive'])

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -2,7 +2,6 @@ import os
 import re
 import json
 import logging
-import uuid
 
 from stix2 import TAXIICollectionSource, Filter
 
@@ -106,28 +105,28 @@ class DataService:
                 await self.dao.insert('attack_uids', dict(uid=k, description=defang_text(v['description']), tid=v['id'],
                                                           name=v['name']))
                 if 'regex_patterns' in v:
-                    [await self.dao.insert('regex_patterns',
-                                           dict(uid=str(uuid.uuid4()), attack_uid=k, regex_pattern=defang_text(x)))
+                    [await self.dao.insert_generate_uid('regex_patterns',
+                                                        dict(attack_uid=k, regex_pattern=defang_text(x)))
                      for x in v['regex_patterns']]
                 if 'similar_words' in v:
-                    [await self.dao.insert('similar_words',
-                                           dict(uid=str(uuid.uuid4()), attack_uid=k, similar_word=defang_text(x)))
+                    [await self.dao.insert_generate_uid('similar_words',
+                                                        dict(attack_uid=k, similar_word=defang_text(x)))
                      for x in v['similar_words']]
                 if 'false_negatives' in v:
-                    [await self.dao.insert('false_negatives',
-                                           dict(uid=str(uuid.uuid4()), attack_uid=k, false_negative=defang_text(x)))
+                    [await self.dao.insert_generate_uid('false_negatives',
+                                                        dict(attack_uid=k, false_negative=defang_text(x)))
                      for x in v['false_negatives']]
                 if 'false_positives' in v:
-                    [await self.dao.insert('false_positives',
-                                           dict(uid=str(uuid.uuid4()), attack_uid=k, false_positive=defang_text(x)))
+                    [await self.dao.insert_generate_uid('false_positives',
+                                                        dict(attack_uid=k, false_positive=defang_text(x)))
                      for x in v['false_positives']]
                 if 'true_positives' in v:
-                    [await self.dao.insert('true_positives',
-                                           dict(uid=str(uuid.uuid4()), attack_uid=k, true_positive=defang_text(x)))
+                    [await self.dao.insert_generate_uid('true_positives',
+                                                        dict(attack_uid=k, true_positive=defang_text(x)))
                      for x in v['true_positives']]
                 if 'example_uses' in v:
-                    [await self.dao.insert('true_positives',
-                                           dict(uid=str(uuid.uuid4()), attack_uid=k, true_positive=defang_text(x)))
+                    [await self.dao.insert_generate_uid('true_positives',
+                                                        dict(attack_uid=k, true_positive=defang_text(x)))
                      for x in v['example_uses']]
         logging.info('[!] DB Item Count: {}'.format(len(await self.dao.get('attack_uids'))))
 
@@ -185,8 +184,7 @@ class DataService:
             await self.dao.insert('attack_uids', dict(uid=k, description=defang_text(v['description']), tid=v['id'],
                                                       name=v['name']))
             if 'example_uses' in v:
-                [await self.dao.insert('true_positives',
-                                       dict(uid=str(uuid.uuid4()), attack_uid=k, true_positive=defang_text(x)))
+                [await self.dao.insert_generate_uid('true_positives', dict(attack_uid=k, true_positive=defang_text(x)))
                  for x in v['example_uses']]
 
     async def status_grouper(self, status):

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -198,7 +198,8 @@ class DataService:
                                                            attack_uid=criteria['attack_uid']))
         number_of_techniques = await self.dao.get('report_sentence_hits', dict(sentence_id=criteria['sentence_id']))
         if len(number_of_techniques) == 0:
-            await self.dao.update('report_sentences', 'uid', criteria['sentence_id'], dict(found_status=0))
+            await self.dao.update('report_sentences', where=dict(uid=criteria['sentence_id']),
+                                  data=dict(found_status=0))
             return dict(status='true')
         else:
             return dict(status='false', id=criteria['sentence_id'])

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -198,7 +198,7 @@ class DataService:
                                                            attack_uid=criteria['attack_uid']))
         number_of_techniques = await self.dao.get('report_sentence_hits', dict(sentence_id=criteria['sentence_id']))
         if len(number_of_techniques) == 0:
-            await self.dao.update('report_sentences', 'uid', criteria['sentence_id'], dict(found_status='false'))
+            await self.dao.update('report_sentences', 'uid', criteria['sentence_id'], dict(found_status=0))
             return dict(status='true')
         else:
             return dict(status='false', id=criteria['sentence_id'])

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -197,7 +197,7 @@ class DataService:
         sentences = await self.dao.get('report_sentences', dict(report_uid=report_id))
         for sentence in sentences:
             sentence['hits'] = await self.get_active_sentence_hits(sentence_id=sentence['uid'])
-            if await self.dao.get('true_positives', dict(sentence_id=sentence['uid'])):
+            if await self.dao.get('report_sentence_hits', dict(sentence_id=sentence['uid'], confirmed=1)):
                 sentence['confirmed'] = 'true'
             else:
                 sentence['confirmed'] = 'false'
@@ -217,6 +217,14 @@ class DataService:
             "WHERE report_sentence_hits.report_uid = ? AND report_sentence_hits.confirmed = 1")
         # Run the SQL select join query
         return await self.dao.raw_select(select_join_query, parameters=tuple([report_id]))
+
+    async def get_confirmed_attacks(self, sentence_id=''):
+        """Function to retrieve confirmed-attack data for a sentence."""
+        select_join_query = (
+            "SELECT attack_uids.* "
+            "FROM (attack_uids INNER JOIN report_sentence_hits ON attack_uids.uid = report_sentence_hits.attack_uid) "
+            "WHERE report_sentence_hits.sentence_id = ? AND report_sentence_hits.confirmed = 1")
+        return await self.dao.raw_select(select_join_query, parameters=tuple([sentence_id]))
 
     async def get_confirmed_techniques_for_report(self, report_id):
         # Get the confirmed hits

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -114,11 +114,13 @@ class DataService:
                                            dict(uid=str(uuid.uuid4()), attack_uid=k, similar_word=defang_text(x)))
                      for x in v['similar_words']]
                 if 'false_negatives' in v:
-                    [await self.dao.insert('false_negatives', dict(uid=k, false_negative=defang_text(x))) for x in
-                     v['false_negatives']]
+                    [await self.dao.insert('false_negatives',
+                                           dict(uid=str(uuid.uuid4()), attack_uid=k, false_negative=defang_text(x)))
+                     for x in v['false_negatives']]
                 if 'false_positives' in v:
-                    [await self.dao.insert('false_positives', dict(uid=k, false_positive=defang_text(x))) for x in
-                     v['false_positives']]
+                    [await self.dao.insert('false_positives',
+                                           dict(uid=str(uuid.uuid4()), attack_uid=k, false_positive=defang_text(x)))
+                     for x in v['false_positives']]
                 if 'true_positives' in v:
                     [await self.dao.insert('true_positives',
                                            dict(uid=str(uuid.uuid4()), attack_uid=k, true_positive=defang_text(x)))
@@ -227,7 +229,7 @@ class DataService:
             f"UNION "
             f"SELECT report_sentences.uid, report_sentence_hits.attack_uid, report_sentence_hits.report_uid, report_sentence_hits.attack_tid, false_negatives.false_negative " 
             f"FROM ((report_sentences INNER JOIN report_sentence_hits ON report_sentences.uid = report_sentence_hits.sentence_id) " 
-            f"INNER JOIN false_negatives ON report_sentence_hits.sentence_id = false_negatives.sentence_id AND report_sentence_hits.attack_uid = false_negatives.uid) " 
+            f"INNER JOIN false_negatives ON report_sentence_hits.sentence_id = false_negatives.sentence_id AND report_sentence_hits.attack_uid = false_negatives.attack_uid) " 
             f"WHERE report_sentence_hits.report_uid = {report_id}")
         # Run the SQL select join query
         hits = await self.dao.raw_select(select_join_query)

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -193,23 +193,6 @@ class DataService:
             report.update(dict(link="/edit/{}".format(report['title'])))
         return reports
 
-    async def last_technique_check(self, criteria):
-        # The sentence and attack IDs
-        sen_id, attack_id = criteria['sentence_id'], criteria['attack_uid']
-        # Delete any sentence-hits where the model didn't initially guess the attack
-        await self.dao.delete('report_sentence_hits', dict(sentence_id=sen_id, attack_uid=attack_id,
-                                                           initial_model_match=0))
-        # For sentence-hits where the model did guess the attack, flag as inactive and unconfirmed
-        await self.dao.update('report_sentence_hits', where=dict(sentence_id=sen_id, attack_uid=attack_id,
-                                                                 initial_model_match=1),
-                              data=dict(active_hit=0, confirmed=0))
-        number_of_techniques = await self.get_active_sentence_hits(sentence_id=sen_id)
-        if len(number_of_techniques) == 0:
-            await self.dao.update('report_sentences', where=dict(uid=sen_id), data=dict(found_status=0))
-            return dict(status='true')
-        else:
-            return dict(status='false', id=sen_id)
-
     async def build_sentences(self, report_id):
         sentences = await self.dao.get('report_sentences', dict(report_uid=report_id))
         for sentence in sentences:

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -229,7 +229,7 @@ class DataService:
         # The SQL select join query to retrieve the confirmed techniques for the report from the database
         select_join_query = (
             "SELECT report_sentences.uid, report_sentence_hits.attack_uid, report_sentence_hits.report_uid, "
-            "report_sentence_hits.attack_tid, report_sentences.text "
+            "report_sentence_hits.attack_tid, report_sentences.text, report_sentence_hits.initial_model_match "
             "FROM (report_sentences INNER JOIN report_sentence_hits "
             "ON report_sentences.uid = report_sentence_hits.sentence_id) "
             "WHERE report_sentence_hits.report_uid = ? AND report_sentence_hits.confirmed = 1")
@@ -243,10 +243,8 @@ class DataService:
         for hit in hits:
             # For each confirmed technique returned,
             # create a technique object and add it to the list of techniques.
-            technique = {}
-            technique['score'] = 1
-            technique['techniqueID'] = hit['attack_tid'] 
-            technique['comment'] = hit['true_positive']
+            technique = {'model_score': hit['initial_model_match'], 'techniqueID': hit['attack_tid'],
+                         'comment': self.web_svc.remove_html_markup_and_found(hit['text'])}
             techniques.append(technique)
         # Return the list of confirmed techniques
         return techniques

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -106,12 +106,12 @@ class DataService:
                 await self.dao.insert('attack_uids', dict(uid=k, description=defang_text(v['description']), tid=v['id'],
                                                           name=v['name']))
                 if 'regex_patterns' in v:
-                    [await self.dao.insert('regex_patterns', dict(uid=str(uuid.uuid4()), attack_uid=k,
-                                                                  regex_pattern=defang_text(x)))
+                    [await self.dao.insert('regex_patterns',
+                                           dict(uid=str(uuid.uuid4()), attack_uid=k, regex_pattern=defang_text(x)))
                      for x in v['regex_patterns']]
                 if 'similar_words' in v:
-                    [await self.dao.insert('similar_words', dict(uid=str(uuid.uuid4()), attack_uid=k,
-                                                                 similar_word=defang_text(x)))
+                    [await self.dao.insert('similar_words',
+                                           dict(uid=str(uuid.uuid4()), attack_uid=k, similar_word=defang_text(x)))
                      for x in v['similar_words']]
                 if 'false_negatives' in v:
                     [await self.dao.insert('false_negatives', dict(uid=k, false_negative=defang_text(x))) for x in
@@ -120,11 +120,13 @@ class DataService:
                     [await self.dao.insert('false_positives', dict(uid=k, false_positive=defang_text(x))) for x in
                      v['false_positives']]
                 if 'true_positives' in v:
-                    [await self.dao.insert('true_positives', dict(uid=k, true_positive=defang_text(x))) for x in
-                     v['true_positives']]
+                    [await self.dao.insert('true_positives',
+                                           dict(uid=str(uuid.uuid4()), attack_uid=k, true_positive=defang_text(x)))
+                     for x in v['true_positives']]
                 if 'example_uses' in v:
-                    [await self.dao.insert('true_positives', dict(uid=k, true_positive=defang_text(x))) for x in
-                     v['example_uses']]
+                    [await self.dao.insert('true_positives',
+                                           dict(uid=str(uuid.uuid4()), attack_uid=k, true_positive=defang_text(x)))
+                     for x in v['example_uses']]
         logging.info('[!] DB Item Count: {}'.format(len(await self.dao.get('attack_uids'))))
 
     async def insert_attack_json_data(self, buildfile):
@@ -181,8 +183,9 @@ class DataService:
             await self.dao.insert('attack_uids', dict(uid=k, description=defang_text(v['description']), tid=v['id'],
                                                       name=v['name']))
             if 'example_uses' in v:
-                [await self.dao.insert('true_positives', dict(uid=k, true_positive=defang_text(x))) for x in
-                 v['example_uses']]
+                [await self.dao.insert('true_positives',
+                                       dict(uid=str(uuid.uuid4()), attack_uid=k, true_positive=defang_text(x)))
+                 for x in v['example_uses']]
 
     async def status_grouper(self, status):
         reports = await self.dao.get('reports', dict(current_status=status))
@@ -218,7 +221,7 @@ class DataService:
         select_join_query = (
             f"SELECT report_sentences.uid, report_sentence_hits.attack_uid, report_sentence_hits.report_uid, report_sentence_hits.attack_tid, true_positives.true_positive " 
             f"FROM ((report_sentences INNER JOIN report_sentence_hits ON report_sentences.uid = report_sentence_hits.uid) " 
-            f"INNER JOIN true_positives ON report_sentence_hits.uid = true_positives.sentence_id AND report_sentence_hits.attack_uid = true_positives.uid) " 
+            f"INNER JOIN true_positives ON report_sentence_hits.uid = true_positives.sentence_id AND report_sentence_hits.attack_uid = true_positives.attack_uid) " 
             f"WHERE report_sentence_hits.report_uid = {report_id} "
             f"UNION "
             f"SELECT report_sentences.uid, report_sentence_hits.attack_uid, report_sentence_hits.report_uid, report_sentence_hits.attack_tid, false_negatives.false_negative " 

--- a/service/ml_svc.py
+++ b/service/ml_svc.py
@@ -5,6 +5,7 @@ import os
 import pandas as pd
 import pickle
 import random
+import uuid
 
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.linear_model import LogisticRegression
@@ -156,8 +157,8 @@ class MLService:
 
     async def ml_techniques_found(self, report_id, sentence):
         sentence_id = await self.dao.insert('report_sentences',
-                                            dict(report_uid=report_id, text=sentence['text'], html=sentence['html'],
-                                                 found_status="true"))
+                                            dict(uid=str(uuid.uuid4()), report_uid=report_id, text=sentence['text'],
+                                                 html=sentence['html'], found_status='true'))
         for technique in sentence['ml_techniques_found']:
             attack_uid = await self.dao.get('attack_uids', dict(name=technique))
             # If the attack cannot be found via the 'name' column, try the 'tid' column
@@ -180,8 +181,9 @@ class MLService:
             attack_technique_name = '{} (m)'.format(attack_uid[0]['name'])
             attack_tid = attack_uid[0]['tid']
             await self.dao.insert('report_sentence_hits',
-                                  dict(uid=sentence_id, attack_uid=attack_technique,
-                                       attack_technique_name=attack_technique_name, report_uid=report_id, attack_tid=attack_tid))
+                                  dict(uid=str(uuid.uuid4()), sentence_id=sentence_id, attack_uid=attack_technique,
+                                       attack_technique_name=attack_technique_name, report_uid=report_id,
+                                       attack_tid=attack_tid))
 
     async def get_true_negs(self):
         true_negs = await self.dao.get('true_negatives')

--- a/service/ml_svc.py
+++ b/service/ml_svc.py
@@ -183,7 +183,7 @@ class MLService:
             await self.dao.insert_generate_uid('report_sentence_hits',
                                                dict(sentence_id=sentence_id, attack_uid=attack_technique,
                                                     attack_technique_name=attack_technique_name, report_uid=report_id,
-                                                    attack_tid=attack_tid))
+                                                    attack_tid=attack_tid, initial_model_match=1))
 
     async def get_true_negs(self):
         true_negs = await self.dao.get('true_negatives')

--- a/service/ml_svc.py
+++ b/service/ml_svc.py
@@ -158,7 +158,7 @@ class MLService:
     async def ml_techniques_found(self, report_id, sentence):
         sentence_id = await self.dao.insert_generate_uid('report_sentences',
                                                          dict(report_uid=report_id, text=sentence['text'],
-                                                              html=sentence['html'], found_status='true'))
+                                                              html=sentence['html'], found_status=1))
         for technique in sentence['ml_techniques_found']:
             attack_uid = await self.dao.get('attack_uids', dict(name=technique))
             # If the attack cannot be found via the 'name' column, try the 'tid' column

--- a/service/ml_svc.py
+++ b/service/ml_svc.py
@@ -5,7 +5,6 @@ import os
 import pandas as pd
 import pickle
 import random
-import uuid
 
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.linear_model import LogisticRegression
@@ -110,6 +109,7 @@ class MLService:
         # Save the newly-built models
         with open(dict_loc, 'wb') as saved_dict:
             pickle.dump(model_dict, saved_dict)
+        logging.info('[#] Finished saving models.')
         return model_dict
 
     @staticmethod
@@ -156,9 +156,9 @@ class MLService:
         return list_of_sentences
 
     async def ml_techniques_found(self, report_id, sentence):
-        sentence_id = await self.dao.insert('report_sentences',
-                                            dict(uid=str(uuid.uuid4()), report_uid=report_id, text=sentence['text'],
-                                                 html=sentence['html'], found_status='true'))
+        sentence_id = await self.dao.insert_generate_uid('report_sentences',
+                                                         dict(report_uid=report_id, text=sentence['text'],
+                                                              html=sentence['html'], found_status='true'))
         for technique in sentence['ml_techniques_found']:
             attack_uid = await self.dao.get('attack_uids', dict(name=technique))
             # If the attack cannot be found via the 'name' column, try the 'tid' column
@@ -180,10 +180,10 @@ class MLService:
             attack_technique = attack_uid[0]['uid']
             attack_technique_name = '{} (m)'.format(attack_uid[0]['name'])
             attack_tid = attack_uid[0]['tid']
-            await self.dao.insert('report_sentence_hits',
-                                  dict(uid=str(uuid.uuid4()), sentence_id=sentence_id, attack_uid=attack_technique,
-                                       attack_technique_name=attack_technique_name, report_uid=report_id,
-                                       attack_tid=attack_tid))
+            await self.dao.insert_generate_uid('report_sentence_hits',
+                                               dict(sentence_id=sentence_id, attack_uid=attack_technique,
+                                                    attack_technique_name=attack_technique_name, report_uid=report_id,
+                                                    attack_tid=attack_tid))
 
     async def get_true_negs(self):
         true_negs = await self.dao.get('true_negatives')

--- a/service/reg_svc.py
+++ b/service/reg_svc.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 
 
 class RegService:
@@ -40,8 +41,8 @@ class RegService:
 
     async def reg_techniques_found(self, report_id, sentence):
         sentence_id = await self.dao.insert('report_sentences',
-                                            dict(report_uid=report_id, text=sentence['text'],
-                                                 html=sentence['html'], found_status="true"))
+                                            dict(uid=str(uuid.uuid4()), report_uid=report_id, text=sentence['text'],
+                                                 html=sentence['html'], found_status='true'))
         for technique in sentence['reg_techniques_found']:
             attack_uid = await self.dao.get('attack_uids', dict(name=technique))
             if not attack_uid:
@@ -52,5 +53,6 @@ class RegService:
             attack_technique_name = '{} (r)'.format(attack_uid[0]['name'])
             attack_tid = attack_uid[0]['tid']
             await self.dao.insert('report_sentence_hits',
-                                  dict(uid=sentence_id, attack_uid=attack_technique,
-                                       attack_technique_name=attack_technique_name, report_uid=report_id, attack_tid = attack_tid))
+                                  dict(uid=str(uuid.uuid4()), sentence_id=sentence_id, attack_uid=attack_technique,
+                                       attack_technique_name=attack_technique_name, report_uid=report_id,
+                                       attack_tid=attack_tid))

--- a/service/reg_svc.py
+++ b/service/reg_svc.py
@@ -54,4 +54,4 @@ class RegService:
             await self.dao.insert_generate_uid('report_sentence_hits',
                                                dict(sentence_id=sentence_id, attack_uid=attack_technique,
                                                     attack_technique_name=attack_technique_name, report_uid=report_id,
-                                                    attack_tid=attack_tid))
+                                                    attack_tid=attack_tid, initial_model_match=1))

--- a/service/reg_svc.py
+++ b/service/reg_svc.py
@@ -1,5 +1,4 @@
 import re
-import uuid
 
 
 class RegService:
@@ -40,9 +39,9 @@ class RegService:
         return html_sentences
 
     async def reg_techniques_found(self, report_id, sentence):
-        sentence_id = await self.dao.insert('report_sentences',
-                                            dict(uid=str(uuid.uuid4()), report_uid=report_id, text=sentence['text'],
-                                                 html=sentence['html'], found_status='true'))
+        sentence_id = await self.dao.insert_generate_uid('report_sentences',
+                                                         dict(report_uid=report_id, text=sentence['text'],
+                                                              html=sentence['html'], found_status='true'))
         for technique in sentence['reg_techniques_found']:
             attack_uid = await self.dao.get('attack_uids', dict(name=technique))
             if not attack_uid:
@@ -52,7 +51,7 @@ class RegService:
             attack_technique = attack_uid[0]['uid']
             attack_technique_name = '{} (r)'.format(attack_uid[0]['name'])
             attack_tid = attack_uid[0]['tid']
-            await self.dao.insert('report_sentence_hits',
-                                  dict(uid=str(uuid.uuid4()), sentence_id=sentence_id, attack_uid=attack_technique,
-                                       attack_technique_name=attack_technique_name, report_uid=report_id,
-                                       attack_tid=attack_tid))
+            await self.dao.insert_generate_uid('report_sentence_hits',
+                                               dict(sentence_id=sentence_id, attack_uid=attack_technique,
+                                                    attack_technique_name=attack_technique_name, report_uid=report_id,
+                                                    attack_tid=attack_tid))

--- a/service/reg_svc.py
+++ b/service/reg_svc.py
@@ -41,7 +41,7 @@ class RegService:
     async def reg_techniques_found(self, report_id, sentence):
         sentence_id = await self.dao.insert_generate_uid('report_sentences',
                                                          dict(report_uid=report_id, text=sentence['text'],
-                                                              html=sentence['html'], found_status='true'))
+                                                              html=sentence['html'], found_status=1))
         for technique in sentence['reg_techniques_found']:
             attack_uid = await self.dao.get('attack_uids', dict(name=technique))
             if not attack_uid:

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -30,7 +30,8 @@ class RestService:
 
     async def set_status(self, criteria=None):
         report_dict = await self.dao.get('reports', dict(title=criteria['file_name']))
-        await self.dao.update('reports', 'uid', report_dict[0]['uid'], dict(current_status=criteria['set_status']))
+        await self.dao.update('reports', where=dict(uid=report_dict[0]['uid']),
+                              data=dict(current_status=criteria['set_status']))
         return dict(status="Report status updated to " + criteria['set_status'])
 
     async def delete_report(self, criteria=None):
@@ -175,10 +176,9 @@ class RestService:
         analyzed_html = await self.ml_svc.combine_ml_reg(ml_analyzed_html, reg_analyzed_html)
 
         # update card to reflect the end of queue
-        await self.dao.update('reports', 'title', criteria['title'], dict(current_status='needs_review'))
+        await self.dao.update('reports', where=dict(title=criteria['title']), data=dict(current_status='needs_review'))
         temp = await self.dao.get('reports', dict(title=criteria['title']))
         criteria['id'] = temp[0]['uid']
-        # criteria['id'] = await self.dao.update('reports', dict(title=criteria['title'], url=criteria['url'],current_status="needs_review"))
         report_id = criteria['id']
         for sentence in analyzed_html:
             if sentence['ml_techniques_found']:
@@ -220,7 +220,8 @@ class RestService:
         # If the found_status for the sentence id is set to false when adding a missing technique
         # then update the found_status value to true for the sentence id in the report_sentence table 
         if sentence_dict[0]['found_status'] == 0:
-            await self.dao.update('report_sentences', 'uid', criteria['sentence_id'], dict(found_status=1))
+            await self.dao.update('report_sentences', where=dict(uid=criteria['sentence_id']),
+                                  data=dict(found_status=1))
         
         # Return status message
         return dict(status='inserted')

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -198,7 +198,8 @@ class RestService:
                 await self.dao.insert('report_sentences', data)
 
         for element in original_html:
-            html_element = dict(report_uid=report_id, text=element['text'], tag=element['tag'], found_status="false")
+            html_element = dict(uid=str(uuid.uuid4()), report_uid=report_id, text=element['text'], tag=element['tag'],
+                                found_status='false')
             await self.dao.insert('original_html', html_element)
         logging.info('Finished analysing report ' + str(report_id))
 

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -26,7 +26,9 @@ class RestService:
         return dict(status="Report status updated to " + criteria['set_status'])
 
     async def delete_report(self, criteria=None):
-        await self.dao.delete('reports', dict(uid=criteria['report_id']))
+        report_id = criteria['report_id']
+        await self.dao.delete('reports', dict(uid=report_id))
+        return dict(status='Successfully deleted report ' + report_id)
 
     async def remove_sentences(self, criteria=None):
         if not criteria['sentence_id']:
@@ -177,7 +179,7 @@ class RestService:
         # The list of SQL commands to run in a single transaction
         sql_commands = []
         # Check this sentence + attack combination isn't already in report_sentence_hits
-        historic_hits = self.dao.get('report_sentence_hits', dict(sentence_id=sen_id, attack_uid=attack_id))
+        historic_hits = await self.dao.get('report_sentence_hits', dict(sentence_id=sen_id, attack_uid=attack_id))
         if historic_hits:
             returned_hit = historic_hits[0]
             # If this attack is already confirmed for this sentence, we are not going to do anything further

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -30,20 +30,13 @@ class RestService:
         await self.dao.delete('reports', dict(uid=report_id))
         return dict(status='Successfully deleted report ' + report_id)
 
-    async def remove_sentences(self, criteria=None):
-        if not criteria['sentence_id']:
-            return dict(status="Please enter a number.")
-        else:
-            true_positives = await self.dao.get('true_positives', dict(sentence_id=criteria['sentence_id']))
-            false_positives = await self.dao.get('false_positives', dict(sentence_id=criteria['sentence_id']))
-            false_negatives = await self.dao.get('false_negatives', dict(sentence_id=criteria['sentence_id']))
-        if not true_positives and not false_positives and not false_negatives:
-            return dict(status="There is no entry for sentence id " + criteria['sentence_id'])
-        else:
-            await self.dao.delete('true_positives', dict(sentence_id=criteria['sentence_id']))
-            await self.dao.delete('false_positives', dict(sentence_id=criteria['sentence_id']))
-            await self.dao.delete('false_negatives', dict(sentence_id=criteria['sentence_id']))
-            return dict(status='Successfully moved sentence ' + criteria['sentence_id'])
+    async def remove_sentence(self, criteria=None):
+        sen_id = criteria['sentence_id']
+        # This is most likely a sentence ID sent through, so delete as expected
+        await self.dao.delete('report_sentences', dict(uid=sen_id))
+        # This could also be an image, so delete from original_html table too
+        await self.dao.delete('original_html', dict(uid=sen_id))
+        return dict(status='Successfully deleted item ' + sen_id)
 
     async def sentence_context(self, criteria=None):
         return await self.data_svc.get_active_sentence_hits(sentence_id=criteria['uid'])

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -22,9 +22,11 @@ class RestService:
         self.seen_report_status = dict()
 
     async def set_status(self, criteria=None):
-        new_status = criteria['set_status']
-        report_dict = await self.dao.get('reports', dict(title=criteria['file_name']))
-        report_id = report_dict[0]['uid']
+        new_status, report_id = criteria['set_status'], criteria['report_id']
+        if new_status == 'completed':
+            unchecked = await self.data_svc.get_unconfirmed_attack_count(report_id=report_id)
+            if unchecked:
+                return dict(error='There are ' + str(unchecked) + ' attacks unconfirmed for this report.')
         await self.dao.update('reports', where=dict(uid=report_id), data=dict(current_status=new_status))
         self.seen_report_status[report_id] = new_status
         return dict(status='Report status updated to ' + new_status)

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -24,7 +24,8 @@ class RestService:
         sentence_dict = await self.dao.get('report_sentences', dict(uid=criteria['sentence_id']))
         sentence_to_strip = sentence_dict[0]['text']
         sentence_to_insert = self.web_svc.remove_html_markup_and_found(sentence_to_strip)
-        await self.dao.insert('false_negatives', dict(sentence_id=sentence_dict[0]['uid'], uid=criteria['attack_uid'],
+        await self.dao.insert('false_negatives', dict(uid=str(uuid.uuid4()), sentence_id=sentence_dict[0]['uid'],
+                                                      attack_uid=criteria['attack_uid'],
                                                       false_negative=sentence_to_insert))
         return dict(status='inserted')
 
@@ -81,7 +82,8 @@ class RestService:
         sentence_dict = await self.dao.get('report_sentences', dict(uid=criteria['sentence_id']))
         sentence_to_insert = await self.web_svc.remove_html_markup_and_found(sentence_dict[0]['text'])
         last = await self.data_svc.last_technique_check(criteria)
-        await self.dao.insert('false_positives', dict(sentence_id=sentence_dict[0]['uid'], uid=criteria['attack_uid'],
+        await self.dao.insert('false_positives', dict(uid=str(uuid.uuid4()), sentence_id=sentence_dict[0]['uid'],
+                                                      attack_uid=criteria['attack_uid'],
                                                       false_positive=sentence_to_insert))
         return dict(status='inserted', last=last)
 
@@ -152,11 +154,11 @@ class RestService:
                 for t in true_pos:
                     tp.append(t['true_positive'])
                 # query for false negatives
-                false_neg = await self.dao.get('false_negatives', dict(uid=row['uid']))
+                false_neg = await self.dao.get('false_negatives', dict(attack_uid=row['uid']))
                 for f in false_neg:
                     tp.append(f['false_negative'])
                 # query for false positives for this technique
-                false_positives = await self.dao.get('false_positives', dict(uid=row['uid']))
+                false_positives = await self.dao.get('false_positives', dict(attack_uid=row['uid']))
                 for fps in false_positives:
                     fp.append(fps['false_positive'])
 

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -52,17 +52,11 @@ class RestService:
             return dict(status='Successfully moved sentence ' + criteria['sentence_id'])
 
     async def sentence_context(self, criteria=None):
-        if criteria['element_tag'] == 'img':
-            return []
-        sentence_hits = await self.dao.get('report_sentence_hits', dict(sentence_id=criteria['uid']))
-        for hit in sentence_hits:
-            hit['element_tag'] = criteria['element_tag']
-        return sentence_hits
+        return await self.dao.get('report_sentence_hits', dict(sentence_id=criteria['uid']))
 
     async def confirmed_sentences(self, criteria=None):
         tmp = []
-        techniques = await self.dao.get('true_positives',
-                                        dict(sentence_id=criteria['sentence_id'], element_tag=criteria['element_tag']))
+        techniques = await self.dao.get('true_positives', dict(sentence_id=criteria['sentence_id']))
         for tech in techniques:
             name = await self.dao.get('attack_uids', dict(uid=tech['attack_uid']))
             tmp.append(name[0])
@@ -73,7 +67,7 @@ class RestService:
         sentence_to_insert = await self.web_svc.remove_html_markup_and_found(sentence_dict[0]['text'])
         await self.dao.insert_generate_uid('true_positives',
                                            dict(sentence_id=sentence_dict[0]['uid'], attack_uid=criteria['attack_uid'],
-                                                true_positive=sentence_to_insert, element_tag=criteria['element_tag']))
+                                                true_positive=sentence_to_insert))
         return dict(status='inserted')
 
     async def false_positive(self, criteria=None):
@@ -213,7 +207,7 @@ class RestService:
         # Insert new row in the false_negatives database table to indicate a new confirmed technique
         await self.dao.insert_generate_uid('false_negatives',
                                            dict(sentence_id=sentence_dict[0]['uid'], attack_uid=criteria['attack_uid'],
-                                                true_positive=sentence_to_insert, element_tag=criteria['element_tag']))
+                                                false_negative=sentence_to_insert))
         
         # Insert new row in the report_sentence_hits database table to indicate a new confirmed technique
         # This is needed to ensure that requests to get all confirmed techniques works correctly

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -216,10 +216,10 @@ class RestService:
 
         # Check this sentence + attack combination isn't already in report_sentence_hits
         historic_hits = self.dao.get('report_sentence_hits', dict(sentence_id=sen_id, attack_uid=attack_id))
-        # If it is, flag it as an active hit
+        # If it is, flag it as an active and confirmed hit
         if historic_hits:
             await self.dao.update('report_sentence_hits', where=dict(sentence_id=sen_id, attack_uid=attack_id),
-                                  data=dict(active_hit=1))
+                                  data=dict(active_hit=1, confirmed=1))
         else:
             # Insert new row in the report_sentence_hits database table to indicate a new confirmed technique
             # This is needed to ensure that requests to get all confirmed techniques works correctly
@@ -227,7 +227,7 @@ class RestService:
                                                dict(sentence_id=sen_id, attack_uid=attack_id,
                                                     attack_technique_name=attack_dict[0]['name'],
                                                     report_uid=sentence_dict[0]['report_uid'],
-                                                    attack_tid=attack_dict[0]['tid']))
+                                                    attack_tid=attack_dict[0]['tid'], confirmed=1))
 
         # If the found_status for the sentence id is set to false when adding a missing technique
         # then update the found_status value to true for the sentence id in the report_sentence table 

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -52,9 +52,9 @@ class RestService:
             return dict(status='Successfully moved sentence ' + criteria['sentence_id'])
 
     async def sentence_context(self, criteria=None):
-        if criteria['element_tag']=='img':
+        if criteria['element_tag'] == 'img':
             return []
-        sentence_hits = await self.dao.get('report_sentence_hits', dict(uid=criteria['uid']))
+        sentence_hits = await self.dao.get('report_sentence_hits', dict(sentence_id=criteria['uid']))
         for hit in sentence_hits:
             hit['element_tag'] = criteria['element_tag']
         return sentence_hits
@@ -193,7 +193,8 @@ class RestService:
             elif sentence['reg_techniques_found']:
                 await self.reg_svc.reg_techniques_found(report_id, sentence)
             else:
-                data = dict(report_uid=report_id, text=sentence['text'], html=sentence['html'], found_status="false")
+                data = dict(uid=str(uuid.uuid4()), report_uid=report_id, text=sentence['text'], html=sentence['html'],
+                            found_status='false')
                 await self.dao.insert('report_sentences', data)
 
         for element in original_html:
@@ -219,7 +220,7 @@ class RestService:
         
         # Insert new row in the report_sentence_hits database table to indicate a new confirmed technique
         # This is needed to ensure that requests to get all confirmed techniques works correctly
-        await self.dao.insert('report_sentence_hits', dict(uid=criteria['sentence_id'],
+        await self.dao.insert('report_sentence_hits', dict(uid=str(uuid.uuid4()), sentence_id=criteria['sentence_id'],
                                                            attack_uid=criteria['attack_uid'],
                                                            attack_technique_name=attack_dict[0]['name'],
                                                            report_uid=sentence_dict[0]['report_uid'],

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -98,7 +98,7 @@ class RestService:
                 self.resources.append(task)
 
     async def start_analysis(self, criteria=None):
-        tech_data = await self.dao.get('attack_uids')
+        tech_data = await self.data_svc.get_techniques()
         attack_dict_loc = 'models/attack_dict.json'
         attack_dict_loc = os.path.join('tram', attack_dict_loc) if self.externally_called else attack_dict_loc
         with open(attack_dict_loc, 'r', encoding='utf_8') as attack_dict_f:

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -46,13 +46,8 @@ class RestService:
     async def sentence_context(self, criteria=None):
         return await self.data_svc.get_active_sentence_hits(sentence_id=criteria['uid'])
 
-    async def confirmed_sentences(self, criteria=None):
-        tmp = []
-        techniques = await self.dao.get('true_positives', dict(sentence_id=criteria['sentence_id']))
-        for tech in techniques:
-            name = await self.dao.get('attack_uids', dict(uid=tech['attack_uid']))
-            tmp.append(name[0])
-        return tmp
+    async def confirmed_attacks(self, criteria=None):
+        return await self.data_svc.get_confirmed_attacks(sentence_id=criteria['sentence_id'])
 
     async def insert_report(self, criteria=None):
         for i in range(len(criteria['title'])):

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -186,11 +186,11 @@ class RestService:
             elif sentence['reg_techniques_found']:
                 await self.reg_svc.reg_techniques_found(report_id, sentence)
             else:
-                data = dict(report_uid=report_id, text=sentence['text'], html=sentence['html'], found_status='false')
+                data = dict(report_uid=report_id, text=sentence['text'], html=sentence['html'], found_status=0)
                 await self.dao.insert_generate_uid('report_sentences', data)
 
         for element in original_html:
-            html_element = dict(report_uid=report_id, text=element['text'], tag=element['tag'], found_status='false')
+            html_element = dict(report_uid=report_id, text=element['text'], tag=element['tag'], found_status=0)
             await self.dao.insert_generate_uid('original_html', html_element)
         logging.info('Finished analysing report ' + str(report_id))
 
@@ -219,8 +219,8 @@ class RestService:
         
         # If the found_status for the sentence id is set to false when adding a missing technique
         # then update the found_status value to true for the sentence id in the report_sentence table 
-        if sentence_dict[0]['found_status'] == 'false':
-            await self.dao.update('report_sentences', 'uid', criteria['sentence_id'], dict(found_status='true'))
+        if sentence_dict[0]['found_status'] == 0:
+            await self.dao.update('report_sentences', 'uid', criteria['sentence_id'], dict(found_status=1))
         
         # Return status message
         return dict(status='inserted')

--- a/service/web_svc.py
+++ b/service/web_svc.py
@@ -189,8 +189,6 @@ class WebService:
         final_element['text'] = element['text']
         final_element['tag'] = element['tag']
         final_element['found_status'] = element['found_status']
-        final_element['hits'] = None
-        final_element['confirmed'] = 'false'
         return final_element
 
 
@@ -201,8 +199,6 @@ class WebService:
         final_element['text'] = single_sentence
         final_element['tag'] = tag
         final_element['found_status'] = sentence['found_status']
-        final_element['hits'] = sentence['hits']
-        final_element['confirmed'] = sentence['confirmed']
         return final_element
 
     @staticmethod

--- a/service/web_svc.py
+++ b/service/web_svc.py
@@ -260,7 +260,7 @@ class WebService:
         img_dict = dict()
         img_dict['text'] = source
         img_dict['tag'] = 'img'
-        img_dict['found_status'] = False
+        img_dict['found_status'] = 0
         img_dict['ml_techniques_found'] = []
         img_dict['res_techniques_found'] = []
         return img_dict
@@ -270,7 +270,7 @@ class WebService:
         res_dict = dict()
         res_dict['text'] = plaintext
         res_dict['tag'] = tag
-        res_dict['found_status'] = False
+        res_dict['found_status'] = 0
         res_dict['ml_techniques_found'] = []
         res_dict['res_techniques_found'] = []
         return res_dict

--- a/service/web_svc.py
+++ b/service/web_svc.py
@@ -170,7 +170,7 @@ class WebService:
                 out = out + c
         sep = '!FOUND:'
         out = out.split(sep, 1)[0]
-        return out
+        return out.strip().replace('\n', ' ')
 
     @staticmethod
     async def get_url(url, returned_format=None):

--- a/webapp/html/about.html
+++ b/webapp/html/about.html
@@ -41,9 +41,9 @@ Note: If a “Needs Review” card pops up right away, this generally means the 
 </p>
 <p>
     <ul style="list-style-type:none;">
-    <li><b>Accepting</b> a technique means the correct technique is in the selected highlighted sentence. That sentence and technique will go to the <b>"True Positives"</b> table in the database.</li>
-    <li><b>Rejecting</b> a technique means the technique is not in the highlighted sentence. That sentence and technique goes to the <b>"False Positives"</b> table in the database.</li>
-    <li><b>Add a Missing Technique</b> allows users to manually add any techniques that were missed in highlighted or un-highlighted sentences. Click the grey button and start typing in the technique you want to map, and click it when it appears. When a missing technique is added, it will be put <b>"True Negatives"</b> table in the database.</li>
+    <li><b>Accepting</b> a technique means the correct technique is in the selected highlighted sentence. That sentence and technique will go to the <b>"True Positives"</b> table in the database (if this is not a missing technique you have introduced).</li>
+    <li><b>Rejecting</b> a technique means the technique is not in the highlighted sentence. That sentence and technique goes to the <b>"False Positives"</b> table in the database (again, if this is not a missing technique you have introduced).</li>
+    <li><b>Add a Missing Technique</b> allows users to manually add any techniques that were missed in highlighted or un-highlighted sentences. Click the grey button and start typing in the technique you want to map, and click it when it appears. When a missing technique is added, it will be put in the <b>"False Negatives"</b> table of the database (if this is not a technique you initially rejected).</li>
     </ul>
     The new data and corresponding tables can then be used to rebuild the models. As more data is fed to the tool, analyst reviewed, and the model rebuilt we expect these predictions to get more accurate.
 </p>

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -58,11 +58,11 @@
                 <img src="{{elmt.text}}" id="img{{elmt.uid}}" class="normalImage" onclick="sentenceContext('{{elmt.uid}}')"> <br><br>
             {% elif elmt.tag == 'header' %}
                 <h3>{{elmt.text}}</h3> 
-            {% elif elmt.tag == 'li' and elmt.found_status == 'true' %}
+            {% elif elmt.tag == 'li' and elmt.found_status == 1 %}
                 <li><a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a></li> <br>
             {% elif elmt.tag == 'li' %}
                 <li><a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a></li> <br>
-            {% elif elmt.found_status == 'true' %}
+            {% elif elmt.found_status == 1 %}
                 <a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a> <br><br>
             {% else %}
                 <a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a> <br><br>

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -28,7 +28,11 @@
     }
 
 	a:hover {
-  	background-color: #ffffbd;
+  	    background-color: #ffffbd;
+	}
+
+	.btn:disabled {
+	    cursor: not-allowed;
 	}
 </style>
 
@@ -55,17 +59,17 @@
     <div class="col reportSentencesDiv">
         {% for elmt in final_html %}
             {% if elmt.tag == 'img' %}
-                <img src="{{elmt.text}}" id="img{{elmt.uid}}" class="normalImage" onclick="sentenceContext('{{elmt.uid}}')"> <br><br>
+                <img src="{{elmt.text}}" id="img{{elmt.uid}}" class="normalImage" onclick="sentenceContext('{{elmt.uid}}')"> <br class="elmtRelated{{elmt.uid}}"><br class="elmtRelated{{elmt.uid}}">
             {% elif elmt.tag == 'header' %}
                 <h3>{{elmt.text}}</h3> 
             {% elif elmt.tag == 'li' and elmt.found_status == 1 %}
-                <li><a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a></li> <br>
+                <li class="elmtRelated{{elmt.uid}}"><a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a></li> <br class="elmtRelated{{elmt.uid}}">
             {% elif elmt.tag == 'li' %}
-                <li><a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a></li> <br>
+                <li class="elmtRelated{{elmt.uid}}"><a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a></li> <br class="elmtRelated{{elmt.uid}}">
             {% elif elmt.found_status == 1 %}
-                <a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a> <br><br>
+                <a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a> <br class="elmtRelated{{elmt.uid}}"><br class="elmtRelated{{elmt.uid}}">
             {% else %}
-                <a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a> <br><br>
+                <a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a> <br class="elmtRelated{{elmt.uid}}"><br class="elmtRelated{{elmt.uid}}">
             {% endif %}
         {% endfor %}
     </div>
@@ -108,7 +112,8 @@
                 </div>
             </div>
             <br>
-            &nbsp;&nbsp;&nbsp;<button id="missingTechBtn" onclick="addMissingTechnique()" class="btn btn-md btn-outline-primary">Add Technique</button> <br><br>
+            <button disabled id="missingTechBtn" onclick="addMissingTechnique()" class="btn btn-md btn-outline-primary">Add Technique</button> <br><br>
+            <button disabled id="delSenBtn" onclick="remove_sentence()" class="btn btn-md btn-danger">Remove Selected</button> <br><br>
         </div>
 
 

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -37,7 +37,9 @@
 </style>
 
 <br>
-
+{% if completed == 0 %}
+    <meta id="reportinfo" data-reportid="{{report_id}}">
+{% endif %}
 <h3 class="display-4 text-center">{{ file }}</h3>
 
 <div class="row justify-content-center pb-3">
@@ -75,45 +77,37 @@
     </div>
     <div class="col col-sm-4 ">
         <div class='missingTechniquesView' id='sentenceContextSection'>
-                <span class='spanMissingTechniqueView'>
-                    Techniques Found
-                </span>
-            <br><br>
-            <div id="sentenceInformation">
-                <table id="tableSentenceInfo" class="table">
-                    <tbody>
-
-                    </tbody>
-                </table>
-            </div>
-            <br><br>
-            <span class='spanMissingTechniqueView'>
-                    Confirmed Techniques
-                </span>
+            {% if completed == 0 %}
+                <span class='spanMissingTechniqueView'>Techniques Found</span>
+                <br><br>
+                <div id="sentenceInformation">
+                    <table id="tableSentenceInfo" class="table"><tbody></tbody></table>
+                </div>
+                <br><br>
+            {% endif %}
+            <span class='spanMissingTechniqueView'>Confirmed Techniques</span>
             <br><br>
             <div id="confirmedsentenceInformation">
-                <table id="confirmedSentenceInfo" class="table">
-                    <tbody>
-
-                    </tbody>
-                </table>
+                <table id="confirmedSentenceInfo" class="table"><tbody></tbody></table>
             </div>
             <hr><br><br>
-             <span class='spanAddMissingTechnique'>
-                    Add A Missing Technique
-                </span> <br><br>
-            <div class="container">
-                <div class="row">
-                  <select id="missingTechniqueSelect" class="selectpicker" data-show-subtext="true" data-live-search="true">
-                      {% for tech in attack_uids %}
-                    <option class="selectDropdownWidth" style="overflow: scroll" value="{{tech.uid}}">{{tech.name}}</option>
-                      {% endfor %}
-                  </select>
+            {% if completed == 0 %}
+                <span class='spanAddMissingTechnique'>Add A Missing Technique</span>
+                <br><br>
+                <div class="container">
+                    <div class="row">
+                      <select id="missingTechniqueSelect" class="selectpicker" data-show-subtext="true" data-live-search="true">
+                          {% for tech in attack_uids %}
+                        <option class="selectDropdownWidth" style="overflow: scroll" value="{{tech.uid}}">{{tech.name}}</option>
+                          {% endfor %}
+                      </select>
+                    </div>
                 </div>
-            </div>
-            <br>
-            <button disabled id="missingTechBtn" onclick="addMissingTechnique()" class="btn btn-md btn-outline-primary">Add Technique</button> <br><br>
-            <button disabled id="delSenBtn" onclick="remove_sentence()" class="btn btn-md btn-danger">Remove Selected</button> <br><br>
+                <br>
+                <button disabled id="missingTechBtn" onclick="addMissingTechnique()" class="btn btn-md btn-outline-primary">Add Technique</button> <br><br>
+                <button disabled id="delSenBtn" onclick="remove_sentence()" class="btn btn-md btn-danger">Remove Selected</button> <br><br>
+                <button onclick="finish_analysis()" class="btn btn-md btn-success">Finish Analysis</button> <br><br>
+            {% endif %}
         </div>
 
 

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -23,6 +23,10 @@
         width: 75%;
     }
 
+    .imgHighlight {
+        border: 25px solid #ffc107;
+    }
+
 	a:hover {
   	background-color: #ffffbd;
 	}
@@ -51,17 +55,17 @@
     <div class="col reportSentencesDiv">
         {% for elmt in final_html %}
             {% if elmt.tag == 'img' %}
-                <img src="{{elmt.text}}" class="normalImage" onclick="sentenceContext('{{elmt.uid}}', 'img')"> <br><br>
+                <img src="{{elmt.text}}" id="img{{elmt.uid}}" class="normalImage" onclick="sentenceContext('{{elmt.uid}}')"> <br><br>
             {% elif elmt.tag == 'header' %}
                 <h3>{{elmt.text}}</h3> 
             {% elif elmt.tag == 'li' and elmt.found_status == 'true' %}
-                <li><a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}', 'p')">{{elmt.text}}</a></li> <br>
+                <li><a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a></li> <br>
             {% elif elmt.tag == 'li' %}
-                <li><a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}', 'p')">{{elmt.text}}</a></li> <br>
+                <li><a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a></li> <br>
             {% elif elmt.found_status == 'true' %}
-                <a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}', 'p')">{{elmt.text}}</a> <br><br>
+                <a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a> <br><br>
             {% else %}
-                <a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}', 'p')">{{elmt.text}}</a> <br><br>
+                <a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</a> <br><br>
             {% endif %}
         {% endfor %}
     </div>
@@ -104,7 +108,7 @@
                 </div>
             </div>
             <br>
-            &nbsp;&nbsp;&nbsp;<button onclick="addMissingTechnique()" class="btn btn-md btn-outline-primary">Add Technique</button> <br><br>
+            &nbsp;&nbsp;&nbsp;<button id="missingTechBtn" onclick="addMissingTechnique()" class="btn btn-md btn-outline-primary">Add Technique</button> <br><br>
         </div>
 
 

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -51,17 +51,17 @@
     <div class="col reportSentencesDiv">
         {% for elmt in final_html %}
             {% if elmt.tag == 'img' %}
-                <img src="{{elmt.text}}" class="normalImage" onclick="sentenceContext({{elmt.uid}}, 'img')"> <br><br>
+                <img src="{{elmt.text}}" class="normalImage" onclick="sentenceContext('{{elmt.uid}}', 'img')"> <br><br>
             {% elif elmt.tag == 'header' %}
                 <h3>{{elmt.text}}</h3> 
             {% elif elmt.tag == 'li' and elmt.found_status == 'true' %}
-                <li><a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext({{elmt.uid}}, 'p')">{{elmt.text}}</a></li> <br>
+                <li><a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}', 'p')">{{elmt.text}}</a></li> <br>
             {% elif elmt.tag == 'li' %}
-                <li><a id="elmt{{elmt.uid}}" onclick="sentenceContext({{elmt.uid}}, 'p')">{{elmt.text}}</a></li> <br>
+                <li><a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}', 'p')">{{elmt.text}}</a></li> <br>
             {% elif elmt.found_status == 'true' %}
-                <a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext({{elmt.uid}}, 'p')">{{elmt.text}}</a> <br><br>
+                <a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}', 'p')">{{elmt.text}}</a> <br><br>
             {% else %}
-                <a id="elmt{{elmt.uid}}" onclick="sentenceContext({{elmt.uid}}, 'p')">{{elmt.text}}</a> <br><br>
+                <a id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}', 'p')">{{elmt.text}}</a> <br><br>
             {% endif %}
         {% endfor %}
     </div>

--- a/webapp/html/index.html
+++ b/webapp/html/index.html
@@ -103,7 +103,7 @@
                                     <p class="card-text">{{report.title}}</p>
                                         <div class="d-flex justify-content-between align-items-center">
                                             <div class="btn-group">
-                                                <a href="{{report.url}}" class="btn btn-sm btn-outline-secondary">View Source</a>
+                                                <a href="{{report.url}}" class="btn btn-sm btn-outline-secondary">Source</a>
                                                 <a href="{{report.link}}" class="btn btn-sm btn-outline-secondary">Analyze</a>
                                             </div>
                                         </div>
@@ -129,8 +129,8 @@
                                     <p class="card-text">{{report.title}}</p>
                                         <div class="d-flex justify-content-between align-items-center">
                                             <div class="btn-group">
-                                                <a href="{{report.url}}" class="btn btn-sm btn-outline-secondary">View Source</a>
-                                                <a href="{{report.link}}" class="btn btn-sm btn-outline-secondary">Analyze</a>
+                                                <a href="{{report.url}}" class="btn btn-sm btn-outline-secondary">Source</a>
+                                                <a href="{{report.link}}" class="btn btn-sm btn-outline-secondary">View Analysis</a>
                                             </div>
                                         </div>
                                 </div>

--- a/webapp/html/index.html
+++ b/webapp/html/index.html
@@ -71,7 +71,7 @@
                                 {% for report in needs_review %}
                                 <div class="card draggable shadow-sm" id="needs_review-{{report.uid}}" draggable="true" ondragstart="drag(event)">
                                 <div class="card-body">
-                                    <a onclick="deleteReport({{report.uid}})"
+                                    <a onclick="deleteReport('{{report.uid}}')"
                                        class="glyphicon glyphicon-trash btn-sm btn-outline-danger float-right"></a>
                                     <p>
                                     <p class="card-text">{{report.title}}</p>
@@ -97,7 +97,7 @@
                                 {% for report in in_review %}
                                 <div class="card draggable shadow-sm" id="review-{{report.uid}}" draggable="true" ondragstart="drag(event)">
                                 <div class="card-body">
-                                    <a onclick="deleteReport({{report.uid}})"
+                                    <a onclick="deleteReport('{{report.uid}}')"
                                        class="glyphicon glyphicon-trash btn-sm btn-outline-danger float-right"></a>
                                     <p>
                                     <p class="card-text">{{report.title}}</p>
@@ -123,7 +123,7 @@
                                 {% for report in completed %}
                                 <div class="card draggable shadow-sm" id="completed-{{report.uid}}" draggable="true" ondragstart="drag(event)">
                                 <div class="card-body">
-                                    <a onclick="deleteReport({{report.uid}})"
+                                    <a onclick="deleteReport('{{report.uid}}')"
                                        class="glyphicon glyphicon-trash btn-sm btn-outline-danger float-right"></a>
                                     <p>
                                     <p class="card-text">{{report.title}}</p>

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -51,7 +51,6 @@ function deleteReport(report_id){
 
 function false_negative(type, attack_uid){
     restRequest('POST', {'index':'false_negative', 'sentence_type':type, 'sentence_id':sentence_id, 'attack_uid':attack_uid}, show_info);
-    alert(sentence_id)
 }
 
 function set_status(set_status, file_name){
@@ -148,8 +147,8 @@ function updateSentenceContext(data) {
     if (data && data.length > 0) {
         $.each(data, function(index, op) {
             td1 = "<td><a href=https://attack.mitre.org/techniques/" + op.attack_tid + " target=_blank>" + op.attack_technique_name + "</a></td>";
-            td2 = `<td><button class='btn btn-success' onclick='true_positive(true_positive, ${op.uid}, \"${op.attack_uid}\", "${op.element_tag}")'>Accept</button></td>`;
-            td3 = `<td><button class='btn btn-danger' onclick='false_positive(true_positive, ${op.uid}, \"${op.attack_uid}\")'>Reject</button></td>`;
+            td2 = `<td><button class='btn btn-success' onclick='true_positive(true_positive, "${op.sentence_id}", "${op.attack_uid}", "${op.element_tag}")'>Accept</button></td>`;
+            td3 = `<td><button class='btn btn-danger' onclick='false_positive(true_positive, "${op.sentence_id}", "${op.attack_uid}")'>Reject</button></td>`;
             tmp = `<tr id="sentence-tid${op.attack_uid.substr(op.attack_uid.length - 4)}">${td1}${td2}${td3}</tr>`;
             $("#tableSentenceInfo").find('tbody').append(tmp);
         });

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -121,7 +121,7 @@ function sentenceContext(data, attack_uid) {
     sentence_id = data;
     // Fire off requests to get info on this sentence
     restRequest('POST', {'index':'sentence_context', 'uid': data, 'attack_uid':attack_uid}, updateSentenceContext);
-    restRequest('POST', {'index':'confirmed_sentences', 'sentence_id': data}, updateConfirmedContext);
+    restRequest('POST', {'index':'confirmed_attacks', 'sentence_id': data}, updateConfirmedContext);
 }
 
 function updateSentenceContext(data) {
@@ -222,7 +222,7 @@ function addMissingTechnique() {
     if($(`.${highlightClassImg}`).length == 0) {
         uid = $("#missingTechniqueSelect :selected").val();
         restRequest('POST', {'index':'add_attack', 'sentence_id': sentence_id, 'attack_uid':uid}, show_info);
-        restRequest('POST', {'index':'confirmed_sentences', 'sentence_id': sentence_id}, updateConfirmedContext);
+        restRequest('POST', {'index':'confirmed_attacks', 'sentence_id': sentence_id}, updateConfirmedContext);
         // If an attack has been added to a temporarily highlighted sentence, the highlighting isn't temporary anymore
         tempHighlighted = undefined
     }

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -69,15 +69,27 @@ function rejectAttack(id, attack_uid) {
     sentenceContext(id, attack_uid);
 }
 
-function deleteReport(report_id){
+function deleteReport(report_id) {
   if (confirm('Are you sure you want to delete this report?')) {
     restRequest('POST', {'index':'delete_report', 'report_id':report_id}, show_info)
     window.location.reload(true);
   }
 }
 
-function set_status(set_status, file_name){
-    restRequest('POST', {'index':'set_status', 'set_status':set_status, 'file_name':file_name}, show_info);
+function finish_analysis() {
+    var report_id = $('meta#reportinfo').data('reportid');
+    if (confirm('Are you sure you are finished with this report?')) {
+        restRequest('POST', {'index':'set_status', 'set_status': 'completed', 'report_id': report_id}, post_analysis);
+    }
+}
+
+function post_analysis(data) {
+    if (data.status) {
+        show_info(data);
+        window.location.reload(true);
+    } else if (data.error) {
+        alert(data.error);
+    }
 }
 
 function submit_report() {
@@ -95,19 +107,19 @@ function submit_report() {
     }
 }
 
-function upload_file(){
+function upload_file() {
   //var fileName = this.val().split("\\").pop();
 
   console.log(document.getElementById("csv_file"))
   var file = document.getElementById("csv_file").files[0];
-  if(file){
+  if(file) {
     var reader = new FileReader();
     reader.readAsText(file, "UTF-8");
-    reader.onload = function(evt){
+    reader.onload = function(evt) {
       console.log(evt.target.result)
       restRequest('POST', {'index':'insert_csv','file':evt.target.result},show_info);
     }
-    reader.onerror = function(evt){
+    reader.onerror = function(evt) {
       alert("Error reading file");
     }
   }
@@ -133,11 +145,11 @@ function filterFunction(input1, id1) {
   }
 }
 
-function show_info(data){
+function show_info(data) {
     console.log(data.status);
 }
 
-function savedAlert(){
+function savedAlert() {
     console.log("saved");
 }
 
@@ -208,7 +220,7 @@ function updateConfirmedContext(data) {
     });
 }
 
-function downloadLayer(data){
+function downloadLayer(data) {
   // Create the name of the JSON download file from the name of the report
   var json = JSON.parse(data) 
   var title = json['name'] //document.getElementById("title").value;
@@ -229,11 +241,11 @@ function downloadLayer(data){
   a.remove();
 }
 
-function viewLayer(data){
+function viewLayer(data) {
   console.info("viewLayer: " + data)
 }
 
-function divSentenceReload(){
+function divSentenceReload() {
     $('#sentenceContextSection').load(document.URL +  ' #sentenceContextSection');
 }
 
@@ -247,8 +259,8 @@ function autoHeight() {
 
  // onDocumentReady function bind
 $(document).ready(function() {
-  $("header").css("height", $(".navbar").outerHeight());
-  autoHeight();
+    $("header").css("height", $(".navbar").outerHeight());
+    autoHeight();
 });
 
 // onResize bind of the function

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -23,16 +23,13 @@ function remove_sentences(){
 }
 
 function acceptAttack(id, attack_uid) {
-    restRequest('POST', {'index':'add_attack', 'sentence_id':id, 'attack_uid':attack_uid}, show_info);
-    // TODO debug and see how this may be spamming Confirmed Techniques list
+    restRequest('POST', {'index':'add_attack', 'sentence_id': id, 'attack_uid': attack_uid}, show_info);
     sentenceContext(id, attack_uid);
 }
 
 function rejectAttack(id, attack_uid) {
-    document.getElementById("sentence-tid" + attack_uid.substr(attack_uid.length - 4)).remove();
-    // TODO replace with a check if this is the last attack being rejected, else we want highlighting to remain
-    $("#elmt" + id).removeClass(highlightClass);
-    restRequest('POST', {'index':'reject_attack', 'sentence_id':id, 'attack_uid':attack_uid}, show_info);
+    restRequest('POST', {'index':'reject_attack', 'sentence_id': id, 'attack_uid': attack_uid}, show_info);
+    sentenceContext(id, attack_uid);
 }
 
 function deleteReport(report_id){
@@ -120,7 +117,7 @@ function sentenceContext(data, attack_uid) {
     // Update selected sentence global variable
     sentence_id = data;
     // Fire off requests to get info on this sentence
-    restRequest('POST', {'index':'sentence_context', 'uid': data, 'attack_uid':attack_uid}, updateSentenceContext);
+    restRequest('POST', {'index':'sentence_context', 'uid': data, 'attack_uid': attack_uid}, updateSentenceContext);
     restRequest('POST', {'index':'confirmed_attacks', 'sentence_id': data}, updateConfirmedContext);
 }
 


### PR DESCRIPTION
A massive re-write of the db schema and its consequent db-calls:

- IDs are not incrementing numbers anymore
- Booleans are not of type TEXT anymore
- Utilised foreign keys
- Enforced each record to have its own unique UID (versus its own UID referencing that of another's)
- Enforced SQL values to be passed as parameters in most execute() calls
- Enabled multiple conditions in WHERE clauses of UPDATE statements
- Enabled != in SELECT (get) calls
- Expanded report_sentence_hits to include:
  - Whether the model initially guessed an attack (to prevent all accepted attacks to be assumed as true positives and other assumptions)
  - Whether the sentence hit is active (inactive hits are where we care about knowing the model-initial-guess but the user rejected the attack so it's not active)
  - Whether the attack is confirmed
- Utilised transactions in accepting/rejecting attacks (due to multiple update/delete calls a single of these actions may have)

Non-db additional work:
- Utilised report statuses -> reports progress through these now
- Can delete sentences and images from a report
- Exported PDFs now state reports are a draft if report status is not 'completed'